### PR TITLE
Fix DeltaNeutralStrategy quantity calculation

### DIFF
--- a/strategies/delta_neutral.py
+++ b/strategies/delta_neutral.py
@@ -16,6 +16,7 @@ class DeltaNeutralStrategy:
         self.symbols = config.get('symbols', ['BTC/USDT', 'ETH/USDT'])
 
     def generate_signals(self, market_snapshot, free_usdt):
+        """Generate hedged buy/sell signals based on snapshot data."""
         try:
             sym1, sym2 = self.symbols
             data1 = market_snapshot.get(sym1)
@@ -24,14 +25,32 @@ class DeltaNeutralStrategy:
                 logging.error(f"Missing data for {sym1} or {sym2}")
                 return []
 
-            ask1 = float(data1['ask'])
-            bid2 = float(data2['bid'])
-            ratio = ask1 / bid2
+            ask1 = float(data1["ask"])
+            bid2 = float(data2["bid"])
 
-            if ratio > 1 + (1 - self.hedge_ratio):
+            ratio = ask1 / bid2
+            threshold = 1 + (1 - self.hedge_ratio)
+
+            if ratio > threshold and free_usdt > 0:
+                # Розподіляємо available USDT згідно з hedge_ratio
+                amount1 = free_usdt * (1 - self.hedge_ratio)
+                amount2 = free_usdt * self.hedge_ratio
+                qty1 = amount1 / ask1
+                qty2 = amount2 / bid2
+
                 return [
-                    {"side": "sell", "symbol": sym1, "price": ask1},
-                    {"side": "buy",  "symbol": sym2, "price": bid2}
+                    {
+                        "side": "sell",
+                        "symbol": sym1,
+                        "price": ask1,
+                        "qty": qty1,
+                    },
+                    {
+                        "side": "buy",
+                        "symbol": sym2,
+                        "price": bid2,
+                        "qty": qty2,
+                    },
                 ]
             return []
         except Exception as e:


### PR DESCRIPTION
## Summary
- include free USDT allocation logic in `DeltaNeutralStrategy`
- calculate quantities and include them in generated signals

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*